### PR TITLE
Fix I.R. Mod Sender. Now, if not find a router with receiver in range,

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/SenderModule.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/itemroutermodules/SenderModule.java
@@ -15,6 +15,7 @@ import io.github.thebusybiscuit.sensibletoolbox.api.STBInventoryHolder;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.blocks.router.ItemRouter;
+import io.github.thebusybiscuit.sensibletoolbox.utils.VanillaInventoryUtils;
 import me.desht.dhutils.Debugger;
 
 public class SenderModule extends DirectionalItemRouterModule {
@@ -80,6 +81,11 @@ public class SenderModule extends DirectionalItemRouterModule {
                     }
 
                     return nReceived > 0;
+                } else {
+                	// Not router found with receiver module in range. Vanilla inventory holder adjacent to source router?
+                	if (VanillaInventoryUtils.isVanillaInventory(target)) {
+                		return vanillaInsertion(target, nToInsert, getFacing().getOppositeFace());
+                	}       
                 }
             } else {
                 BaseSTBBlock stb = SensibleToolbox.getBlockAt(target.getLocation(), true);


### PR DESCRIPTION
but adjacent is a vanilla inventory, router will try to move item to vanilla inventory. This FIX bug with I.R. Mod Sender don't move items to vanilla inventory, adjacent to router.

## Description
<!-- Please explain what you changed/added and why you did it in detail. -->

## Changes
<!-- Please list all the changes you have made. -->

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
